### PR TITLE
Improve README clone command and flash-attn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Inspired by [TinyZero](https://github.com/Jiayi-Pan/TinyZero) and [Mini-R1](http
 3. **Run the training script**  
    Open `nano_r1.ipynb` or `nano_r1_script.py` and start training.
 
-   > If using uv, you can run with either `uv run r1_script.py` or activate the env with `source .venv/bin/activate` and run with `python nano_r1_script.py`
+   > If using uv, you can run with either `uv run nano_r1_script.py` or activate the env with `source .venv/bin/activate` and run with `python nano_r1_script.py`
 
 ## Todos
 - [ ] Full evaluation suite

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Inspired by [TinyZero](https://github.com/Jiayi-Pan/TinyZero) and [Mini-R1](http
 
 1. **Clone the repository**  
    ```bash
-   git clone git@github.com:McGill-NLP/nano-aha-moment.git
+   git clone https://github.com/McGill-NLP/nano-aha-moment.git
    ```
 
 2. **Install dependencies**  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "ipykernel==6.29.5",
     "ipywidgets==8.1.5",
     "jupyter==1.1.1",
-    "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.2.post1/flash_attn-2.7.2.post1+cu12torch2.5cxx11abiFALSE-cp310-cp310-linux_x86_64.whl",
+    "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.2.post1/flash_attn-2.7.2.post1+cu12torch2.5cxx11abiFALSE-cp310-cp310-linux_x86_64.whl",
 ]
 
 # flash-attn related setups


### PR DESCRIPTION
 This PR includes two minor updates:

1. Replaces the SSH-based `git clone` command in the README with an HTTPS version for easier access, especially for users without SSH set up.
2. Updates the `flash-attn` dependency in `pyproject.toml` to use PEP 508-compliant syntax (`flash-attn @ URL`) so tools like `uv` can properly resolve it.

Both changes are backward-safe and improve onboarding experience for new contributors or users trying to set up the project.